### PR TITLE
feat: add crypto wallet leakage signature

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -308,13 +308,13 @@ flowchart LR
 
 ## Signature Catalog
 
-The firewall ships with **100 detection signatures** across 5 categories:
+The firewall ships with **101 detection signatures** across 5 categories:
 
 | Category | Count | Engines | Direction |
 |----------|-------|---------|-----------|
 | Prompt Injection | 67 | heuristic (45), classifier (7), semantic (10), composite (5) | input |
 | Content Safety | 9 | classifier (6), heuristic (3) | input/output |
-| Data Leakage | 14 | heuristic (14) | output |
+| Data Leakage | 15 | heuristic (15) | output |
 | Agentic | 6 | heuristic (6) | input |
 | System Prompt | 4 | heuristic (4) | input/output |
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Tests](https://img.shields.io/badge/tests-161%20passed-brightgreen)](https://github.com/inferwall/inferwall/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/pypi/pyversions/inferwall)](https://pypi.org/project/inferwall/)
 [![Downloads](https://img.shields.io/pypi/dm/inferwall)](https://pypi.org/project/inferwall/)
-[![Signatures](https://img.shields.io/badge/signatures-100-blue)](docs/SIGNATURE_CATALOG.md)
+[![Signatures](https://img.shields.io/badge/signatures-101-blue)](docs/SIGNATURE_CATALOG.md)
 
 **AI application firewall for LLM-powered apps.**
 
@@ -41,7 +41,7 @@ result = inferwall.scan_output("Your API key is sk-1234...")
 
 ## Features
 
-- **100 detection signatures** across 5 categories (injection, content safety, data leakage, system prompt, agentic)
+- **101 detection signatures** across 5 categories (injection, content safety, data leakage, system prompt, agentic)
 - **Rust-powered heuristic engine** — <0.3ms p99 for pattern matching
 - **ML engines** — ONNX classifier (DeBERTa/DistilBERT) + FAISS semantic similarity
 - **Semantic detection engine** — FAISS + MiniLM embeddings for paraphrased attack detection
@@ -52,7 +52,7 @@ result = inferwall.scan_output("Your API key is sk-1234...")
 
 ## MITRE ATLAS Coverage
 
-InferenceWall maps all 100 detection signatures to the [MITRE ATLAS](https://atlas.mitre.org/) framework (Adversarial Threat Landscape for AI Systems). ATLAS is the AI/ML counterpart to MITRE ATT&CK — a knowledge base of adversary tactics and techniques targeting AI systems.
+InferenceWall maps all 101 detection signatures to the [MITRE ATLAS](https://atlas.mitre.org/) framework (Adversarial Threat Landscape for AI Systems). ATLAS is the AI/ML counterpart to MITRE ATT&CK — a knowledge base of adversary tactics and techniques targeting AI systems.
 
 InferenceWall implements these ATLAS mitigations:
 - **AML.M0015** Adversarial Input Detection — detect and block atypical queries

--- a/docs/SIGNATURE_CATALOG.md
+++ b/docs/SIGNATURE_CATALOG.md
@@ -1,6 +1,6 @@
 # InferenceWall Signature Catalog
 
-**Version**: 0.1.6 — **Total**: 100 signatures across 5 categories
+**Version**: 0.1.6 — **Total**: 101 signatures across 5 categories
 
 ## Summary
 
@@ -8,7 +8,7 @@
 |----------|-------|-------------|-----------|
 | Prompt Injection | 67 | heuristic (45), classifier (7), semantic (10), composite (5) | input |
 | Content Safety | 9 | classifier (6), heuristic (3) | input/output |
-| Data Leakage | 14 | heuristic (14) | output |
+| Data Leakage | 15 | heuristic (15) | output |
 | System Prompt | 4 | heuristic (4) | input/output |
 | Agentic | 6 | heuristic (6) | input |
 
@@ -16,7 +16,7 @@
 
 | Profile | Engines | Signatures Used | Latency |
 |---------|---------|----------------|---------|
-| Lite | Heuristic (Rust) | 75 heuristic | <1ms |
+| Lite | Heuristic (Rust) | 76 heuristic | <1ms |
 | Standard | + DeBERTa + DistilBERT + FAISS | + 11 classifier + 10 semantic | ~500ms |
 | Full | + LLM Judge | + composite (ambiguous only) | ~5s |
 
@@ -47,6 +47,7 @@
 | DL-P-006 | Date of Birth Patterns | heuristic | output | data-leakage | medium | medium | 4 | AML.T0057 |
 | DL-P-007 | IP Addresses | heuristic | output | data-leakage | low | high | 3 | AML.T0057 |
 | DL-P-008 | Medical Record Numbers | heuristic | output | data-leakage | high | high | 8 | AML.T0057 |
+| DL-P-009 | Cryptocurrency Wallet Addresses | heuristic | output | data-leakage | medium | high | 6 | AML.T0057 |
 | DL-S-001 | API Keys | heuristic | output | data-leakage | critical | high | 12 | AML.T0057, AML.T0055 |
 | DL-S-002 | Connection Strings | heuristic | output | data-leakage | critical | high | 12 | AML.T0057, AML.T0055 |
 | DL-S-003 | JWT Tokens | heuristic | output | data-leakage | high | high | 8 | AML.T0057, AML.T0055 |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -142,7 +142,7 @@ InferenceWall uses a **three-layer catalog merge** system that lets you customiz
 
 Place custom signature YAML files in `~/.inferwall/signatures/`. These are merged with the shipped catalog at startup:
 
-1. **Shipped catalog** (read-only, inside the pip package) — the built-in 100 signatures
+1. **Shipped catalog** (read-only, inside the pip package) — the built-in 101 signatures
 2. **Custom signatures** (`~/.inferwall/signatures/`) — your additions and overrides
 3. **Override by ID** — a custom signature with the same ID as a shipped one replaces it entirely
 

--- a/docs/signature-authoring.md
+++ b/docs/signature-authoring.md
@@ -1,6 +1,6 @@
 # Signature Authoring Guide
 
-InferenceWall ships with **100 detection signatures** across 5 categories. Community-contributed signatures are licensed under **CC BY-SA 4.0** -- any modifications must be shared back under the same license.
+InferenceWall ships with **101 detection signatures** across 5 categories. Community-contributed signatures are licensed under **CC BY-SA 4.0** -- any modifications must be shared back under the same license.
 
 ## Signature Format
 
@@ -141,7 +141,7 @@ InferenceWall resolves signatures through a **three-layer catalog merge**:
 
 | Layer | Location | Writable | Purpose |
 |-------|----------|----------|---------|
-| **Shipped catalog** | Inside the pip package (`inferwall/catalog/`) | Read-only | The built-in 100 signatures |
+| **Shipped catalog** | Inside the pip package (`inferwall/catalog/`) | Read-only | The built-in 101 signatures |
 | **Custom signatures** | `~/.inferwall/signatures/` | Yes | Your additions and overrides |
 
 ### Override by ID

--- a/src/inferwall/catalog/data-leakage/DL-P-009.yaml
+++ b/src/inferwall/catalog/data-leakage/DL-P-009.yaml
@@ -1,0 +1,31 @@
+# License: CC BY-SA 4.0 — https://creativecommons.org/licenses/by-sa/4.0/
+signature:
+  id: DL-P-009
+  name: Cryptocurrency Wallet Addresses
+  version: "1.0.0"
+meta:
+  category: data-leakage
+  subcategory: pii
+  technique: crypto-wallet-address-detection
+  atlas: ["AML.T0057"]
+  severity: medium
+  confidence: high
+  performance_cost: low
+  tags: [pii, crypto, wallet-address, blockchain, data-leakage]
+detection:
+  engine: heuristic
+  direction: output
+  patterns:
+    - type: regex
+      value: "\\b0x[a-fA-F0-9]{40}\\b"
+    - type: regex
+      value: "\\b(?:[13][a-km-zA-HJ-NP-Z1-9]{25,34}|[bB][cC]1[ac-hj-np-zAC-HJ-NP-Z02-9]{11,71})\\b"
+    - type: regex
+      value: "\\b[1-9A-HJ-NP-Za-km-z]{32,44}\\b"
+  condition: any
+scoring:
+  anomaly_points: 6
+tuning:
+  enabled: true
+  default_enabled: true
+  default_action: enforce

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -35,7 +35,7 @@ class TestHealthEndpoints:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "healthy"
-        assert data["signature_count"] == 100
+        assert data["signature_count"] == 101
 
     def test_health_live(self, client: TestClient) -> None:
         response = client.get("/v1/health/live")

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -8,7 +8,7 @@ class TestPipelineSetup:
 
     def test_pipeline_initializes(self) -> None:
         pipeline = Pipeline()
-        assert pipeline.signature_count == 100
+        assert pipeline.signature_count == 101
 
     def test_pipeline_loads_signatures(self) -> None:
         pipeline = Pipeline()

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -79,6 +79,7 @@ EXPECTED_SIGS = {
     "DL-P-006",
     "DL-P-007",
     "DL-P-008",
+    "DL-P-009",
     # Data leakage — secrets (M3)
     "DL-S-004",
     "DL-S-005",
@@ -137,11 +138,11 @@ class TestCatalogLoads:
     def test_catalog_directory_exists(self) -> None:
         assert CATALOG_DIR.exists()
 
-    def test_all_70_signatures_load(self) -> None:
+    def test_all_catalog_signatures_load(self) -> None:
         loader = SignatureLoader(CATALOG_DIR)
         sigs = loader.load()
-        assert len(sigs) == 100, (
-            f"Expected 100, got {len(sigs)}. Errors: {loader.errors}"
+        assert len(sigs) == 101, (
+            f"Expected 101, got {len(sigs)}. Errors: {loader.errors}"
         )
         assert len(loader.errors) == 0
 
@@ -156,7 +157,7 @@ class TestCatalogLoads:
         loader.load()
         groups = loader.group_by_engine()
         assert "heuristic" in groups
-        assert len(groups["heuristic"]) == 75
+        assert len(groups["heuristic"]) == 76
         assert "classifier" in groups
         assert len(groups["classifier"]) == 11
         assert "semantic" in groups
@@ -178,7 +179,7 @@ class TestCatalogLoads:
         output_sigs = [
             s for s in loader.load() if s.detection.direction.value == "output"
         ]
-        assert len(output_sigs) == 17
+        assert len(output_sigs) == 18
 
     def test_anomaly_points_in_valid_range(self) -> None:
         loader = SignatureLoader(CATALOG_DIR)

--- a/tests/unit/test_crypto_wallet_signature.py
+++ b/tests/unit/test_crypto_wallet_signature.py
@@ -1,0 +1,49 @@
+"""Regression tests for cryptocurrency wallet address leakage signatures."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from inferwall.signatures.loader import SignatureLoader
+
+CATALOG_DIR = Path(__file__).parent.parent.parent / "src" / "inferwall" / "catalog"
+SIGNATURE_ID = "DL-P-009"
+
+
+def _crypto_patterns() -> list[re.Pattern[str]]:
+    loader = SignatureLoader(CATALOG_DIR)
+    loader.load()
+    sig = loader.get_by_id(SIGNATURE_ID)
+
+    assert sig is not None
+    assert sig.detection.patterns is not None
+    return [re.compile(pattern.value or "") for pattern in sig.detection.patterns]
+
+
+def _matches_any_pattern(text: str) -> bool:
+    return any(pattern.search(text) for pattern in _crypto_patterns())
+
+
+def test_crypto_wallet_signature_matches_common_wallet_formats() -> None:
+    examples = [
+        "Send the refund to 0x52908400098527886E0F7030069857D2E4169EE7.",
+        "Bitcoin payout address: 1BoatSLRHtKNngkdXEeobR76b53LETtpyT.",
+        "BTC bech32 address: bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080.",
+        "Solana wallet: 4Nd1mJ8mXH7UzWuh8VZpFqqY5nC8YZvD4n8C5X2Qw3hA.",
+    ]
+
+    for example in examples:
+        assert _matches_any_pattern(example)
+
+
+def test_crypto_wallet_signature_avoids_common_non_wallet_strings() -> None:
+    examples = [
+        "The transaction fee is 0.005 ETH and chain id is 1.",
+        "The UUID is 550e8400-e29b-41d4-a716-446655440000.",
+        "The SHA-256 prefix is 9f86d081884c7d659a2feaa0c55ad015.",
+        "Contact support with ticket TB-2026-04-28-0001.",
+    ]
+
+    for example in examples:
+        assert not _matches_any_pattern(example)

--- a/tests/unit/test_three_layer.py
+++ b/tests/unit/test_three_layer.py
@@ -56,7 +56,7 @@ class TestThreeLayerMerge:
         """Default load_merged picks up shipped catalog."""
         loader = SignatureLoader()
         sigs = loader.load_merged()
-        assert len(sigs) == 100
+        assert len(sigs) == 101
         assert len(loader.errors) == 0
 
     def test_custom_sigs_override_shipped(
@@ -78,7 +78,7 @@ class TestThreeLayerMerge:
             sigs = loader.load_merged()
 
             # Should still have same count (override, not add)
-            assert len(sigs) == 100
+            assert len(sigs) == 101
 
             # The overridden sig should have new points
             sig = loader.get_by_id("INJ-D-001")
@@ -101,8 +101,8 @@ class TestThreeLayerMerge:
             loader = SignatureLoader()
             sigs = loader.load_merged()
 
-            # 100 shipped + 1 custom
-            assert len(sigs) == 101
+            # 101 shipped + 1 custom
+            assert len(sigs) == 102
 
             custom = loader.get_by_id("CUSTOM-001")
             assert custom is not None
@@ -134,7 +134,7 @@ class TestThreeLayerMerge:
         try:
             loader = SignatureLoader()
             sigs = loader.load_merged()
-            assert len(sigs) == 100  # Just shipped
+            assert len(sigs) == 101  # Just shipped
         finally:
             os.environ.pop("IW_SIGNATURES_DIR", None)
 


### PR DESCRIPTION
## Summary
- Adds `DL-P-009`, a heuristic output signature for cryptocurrency wallet address leakage.
- Covers Ethereum, Bitcoin legacy/P2SH, Bitcoin Bech32, and Solana-style base58 wallet formats.
- Updates catalog counts/docs/tests from 100 to 101 shipped signatures.
- Adds explicit true-positive and false-positive tests for the new signature patterns.

## Validation
- `PYTHONPATH=src uv run --extra dev pytest tests/unit/test_catalog.py tests/unit/test_three_layer.py tests/unit/test_crypto_wallet_signature.py`
- `PYTHONPATH=src uv run --extra dev pytest tests/integration/test_pipeline.py::TestPipelineSetup::test_pipeline_initializes tests/integration/test_api.py::TestHealthEndpoints::test_health`
- `PYTHONPATH=src uv run --extra dev ruff check tests/unit/test_crypto_wallet_signature.py tests/unit/test_catalog.py tests/unit/test_three_layer.py tests/integration/test_api.py tests/integration/test_pipeline.py`
- `git diff --check`

Closes #11
